### PR TITLE
Fix image paths in wrapping-it-up blog post

### DIFF
--- a/blog/wrapping-it-up.html
+++ b/blog/wrapping-it-up.html
@@ -1,6 +1,6 @@
 You have probably already seen codes such as "EMB 56251e" or "EN 38.012.001 CE" on food labels and packaging. And you probably did not pay any attention to them. And yet, these codes - called "packager codes" for the first and "European sanitary stamps" for the second - can teach us a lot about the products we buy and eat!<br>
 <br>
-<img title="European and French packer codes" width="160" height="145" src="https://blog.openfoodfacts.org/wp-content/uploads/2022/05/emb_codes.jpg" alt="European and French packager codes">  <img title="European packager code" width="300" height="134" src="https://blog.openfoodfacts.org/wp-content/uploads/2022/05/code_emballeur_europeen.png" alt="European packager code"><br>
+<img title="European and French packer codes" width="160" height="145" src="https://static.openfoodfacts.org/images/blog/emb_codes.jpg" alt="European and French packager codes">  <img title="European packager code" width="300" height="134" src="https://static.openfoodfacts.org/images/blog/code_emballeur_europeen.png" alt="European packager code"><br>
 <h3><b><br>
 A packaging code or sanitary stamp = a company</b></h3>
 The packaging code identifies the company that packaged the food product. This may be the company that made the product, or the company that imported it and packed it.<br>
@@ -12,7 +12,7 @@ The European sanitary stamp or European sanitary approval number identifies the 
 The first 2 digits of the code "EMB 56251e" identify the department, here 56, Morbihan.<br>
 The next 3 digits identify the municipality where the company is located. But it is not the postal code, it is a number attributed to the commune by the INSEE. The number 251 of the french department of Morbihan is Theix.<br>
 <br>
-<a href="https://www.openstreetmap.org/?lat=48.35&amp;lon=6.4&amp;zoom=6&amp;layers=M"><img title="Theix, Morbihan" width="368" height="215" src="https://blog.openfoodfacts.org/wp-content/uploads/2022/05/theix_morbihan.png" alt="Theix, Morbihan"></a><br>
+<a href="https://www.openstreetmap.org/?lat=48.35&amp;lon=6.4&amp;zoom=6&amp;layers=M"><img title="Theix, Morbihan" width="368" height="215" src="https://static.openfoodfacts.org/images/blog/theix_morbihan.png" alt="Theix, Morbihan"></a><br>
 Map by <a href="https://www.openstreetmap.org/?lat=48.35&amp;lon=6.4&amp;zoom=6&amp;layers=M">OpenStreetMap</a> and contributors, <a href="https://creativecommons.org/licenses/by-sa/2.0/">Creative Commons</a> License <a href="https://creativecommons.org/licenses/by-sa/2.0/">cc-by-sa</a> .<br>
 <br>
 To these figures may be added a letter that differentiates food companies when several are established in the same municipality.<br>
@@ -30,7 +30,7 @@ Another very interesting use of <a href="https://world.openfoodfacts.org/package
 <br>
 So our company in Theix code <a href="https://world.openfoodfacts.org/packager-code/emb-56251e">EMB 56251e</a> prepares as well <b>boxes of green beans for the D'Aucy brand as well as boxes of lentils prepared for Cora</b> .<br>
 <br>
-<a href="https://world.openfoodfacts.org/packager-code/emb-56251e"><img title="Products packaged by the same company" width="434" height="406" src="https://blog.openfoodfacts.org/wp-content/uploads/2022/05/EMB56251E.png" alt="Products packaged by the same company" style="border:1px solid"></a><br>
+<a href="https://world.openfoodfacts.org/packager-code/emb-56251e"><img title="Products packaged by the same company" width="434" height="406" src="https://static.openfoodfacts.org/images/blog/EMB56251E.png" alt="Products packaged by the same company" style="border:1px solid"></a><br>
 <br>
 Another example: a factory in Normandy in <a href="https://world.openfoodfacts.org/packager-code/fr-50-139-001-ce">Condé sur Vire</a> that produces Elle &amp; Vire cream and Carrefour half-salt butter.<br>
 <br>


### PR DESCRIPTION

### What
- Fixes hardcoded image paths in the wrapping-it-up blog post

### How
- Replaced old WordPress image URLs with the correct new blog image paths

### Scope
- Updated only image `src` attributes in `blog/wrapping-it-up.html`

Fixes #44
